### PR TITLE
1715: milestone color with jquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* [PR-19](https://github.com/ITK-Leantime/project-overview/pull/19)
+  Fix milestone text color so it is always white when a milestone is chosen, always black when not.
+
 ## [2.0.3] - 2024-09-19
 
 * [PR-13](https://github.com/ITK-Leantime/project-overview/pull/16)

--- a/assets/project-overview.js
+++ b/assets/project-overview.js
@@ -159,11 +159,13 @@ function changeMilestone(event, ticketId, newMilestoneId) {
         const newMilestoneColor = jQuery(
           `#milestone-option-${newMilestoneId}`
         ).attr('data-color');
-        const isItAHexColor = hexColorRegExp.exec(newMilestoneColor);
 
+        const isItAHexColor = hexColorRegExp.exec(newMilestoneColor);
         if (isItAHexColor) {
           jQuery(parentElement).css('background', newMilestoneColor);
+          jQuery("#milestone-select").addClass("milestone-select-white-text");
         } else {
+          jQuery("#milestone-select").removeClass("milestone-select-white-text");
           jQuery(parentElement).css('background', 'transparent');
         }
       });

--- a/assets/project-overview.js
+++ b/assets/project-overview.js
@@ -163,9 +163,11 @@ function changeMilestone(event, ticketId, newMilestoneId) {
         const isItAHexColor = hexColorRegExp.exec(newMilestoneColor);
         if (isItAHexColor) {
           jQuery(parentElement).css('background', newMilestoneColor);
-          jQuery("#milestone-select").addClass("milestone-select-white-text");
+          jQuery('#milestone-select').addClass('milestone-select-white-text');
         } else {
-          jQuery("#milestone-select").removeClass("milestone-select-white-text");
+          jQuery('#milestone-select').removeClass(
+            'milestone-select-white-text'
+          );
           jQuery(parentElement).css('background', 'transparent');
         }
       });


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/dashboard/home?tab=ticketdetails#/tickets/showTicket/1715

#### Description

Fix milestone text color so it is always white when a milestone is chosen, always black when not.

#### Screenshot of the result

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/7d365a3c-858d-434b-ab09-10411ff68e7a">

**CLICK CLICK**

--->


<img width="1175" alt="image" src="https://github.com/user-attachments/assets/595b1c2d-1311-4d5f-a850-e93e17dede08">

## Documentation

Documentation not updated as this is a small bugfix that does not affect anything in the setup.


