### PR TITLE
Hotfix: Explicitly define start and end of week

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* [PR-47](https://github.com/ITK-Leantime/project-overview/pull/47)
+  * Explicitly defined start and end of week
+
 ## [3.0.2] - 2025-04-01
 
 * [PR-45](https://github.com/ITK-Leantime/project-overview/pull/45)

--- a/Controllers/ProjectOverview.php
+++ b/Controllers/ProjectOverview.php
@@ -82,7 +82,7 @@ class ProjectOverview extends Controller
                     $fromDate = CarbonImmutable::createFromFormat('Y-m-d', $_GET['fromDate'])->startOfDay();
                 }
             } else {
-                $fromDate = CarbonImmutable::now()->startOfWeek()->startOfDay();
+                $fromDate = CarbonImmutable::now()->startOfWeek(CarbonImmutable::MONDAY)->startOfDay();
             }
 
             if (isset($_GET['toDate']) && $_GET['toDate'] !== '') {
@@ -92,11 +92,11 @@ class ProjectOverview extends Controller
                     $toDate = CarbonImmutable::createFromFormat('Y-m-d', $_GET['toDate'])->endOfDay();
                 }
             } else {
-                $toDate = CarbonImmutable::now()->endOfWeek()->endOfDay();
+                $toDate = CarbonImmutable::now()->endOfWeek(CarbonImmutable::SUNDAY)->endOfDay();
             }
         } catch (\Exception $e) {
-            $fromDate = CarbonImmutable::now()->startOfWeek()->startOfDay();
-            $toDate = CarbonImmutable::now()->endOfWeek()->endOfDay();
+            $fromDate = CarbonImmutable::now()->startOfWeek(CarbonImmutable::MONDAY)->startOfDay();
+            $toDate = CarbonImmutable::now()->endOfWeek(CarbonImmutable::SUNDAY)->endOfDay();
         }
 
         if (isset($_GET['userIds']) && $_GET['userIds'] !== '') {


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

Manually defines start and end day of week to solve timezone issues across environments.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
