### PR TITLE
feat: Unsaved view filter configuration retention via localstorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   * Extract filter JS into a separate module.
 * [PR-93](https://github.com/ITK-Leantime/project-overview/pull/93)
   * Add reset button that reverts unsaved filter changes.
+* [PR-94](https://github.com/ITK-Leantime/project-overview/pull/94)
+  * Persist "+ new view" filter draft in localStorage across page reloads.
 
 ## [4.3.0] - 2026-05-27
 

--- a/assets/filters.js
+++ b/assets/filters.js
@@ -396,6 +396,16 @@ export function initProjectOverviewFilters({
       serializeFilterForm(filtersForm) !== initialState;
     toggleUnsavedIndicator(activeViewId, hasChanges);
 
+    // Persist the "+ new view" draft to localStorage so it survives a page
+    // reload. Saved views live on the server; only `__new` needs this.
+    if (activeViewId === '__new') {
+      if (hasChanges) {
+        saveNewViewFiltersToStorage(filtersForm);
+      } else {
+        clearNewViewFiltersStorage();
+      }
+    }
+
     clearTimeout(filterDebounceTimer);
     filterDebounceTimer = setTimeout(function () {
       refreshViewTable(filtersForm);
@@ -966,6 +976,61 @@ export function restoreFormState(state) {
   }
 }
 
+/**
+ * localStorage key for the draft state of the synthetic "+ new view" tab.
+ * Filters on a saved view live on the server, but `__new` is purely
+ * client-side until the user names and saves it — without persistence, a
+ * page reload would lose the draft.
+ */
+const NEW_VIEW_FILTERS_STORAGE_KEY = 'projectOverview.newViewFilters';
+
+function readNewViewFiltersFromStorage() {
+  try {
+    const raw = localStorage.getItem(NEW_VIEW_FILTERS_STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+}
+
+function saveNewViewFiltersToStorage(form) {
+  try {
+    localStorage.setItem(
+      NEW_VIEW_FILTERS_STORAGE_KEY,
+      JSON.stringify(captureFormState(form))
+    );
+  } catch (e) {
+    // localStorage may be unavailable (private mode, quota); ignore silently.
+  }
+}
+
+/**
+ * Remove any persisted draft for the "+ new view" tab. Called when the
+ * draft becomes irrelevant: the user has reset it, returned it to the
+ * pristine default, or saved it as a real named view.
+ */
+export function clearNewViewFiltersStorage() {
+  try {
+    localStorage.removeItem(NEW_VIEW_FILTERS_STORAGE_KEY);
+  } catch (e) {}
+}
+
+/**
+ * Seed the in-memory `_viewCachedFormData['__new']` slot from localStorage
+ * if a persisted draft exists. The existing htmx:afterSettle restore in the
+ * entrypoint already restores from `_viewCachedFormData` on a tab swap, so
+ * seeding lets us reuse that path on first paint after a reload.
+ *
+ * Idempotent — safe to call on every page load.
+ */
+export function seedNewViewCacheFromStorage() {
+  const stored = readNewViewFiltersFromStorage();
+  if (!stored) return;
+  if (!window._viewCachedFormData) window._viewCachedFormData = {};
+  window._viewCachedFormData['__new'] = stored;
+}
+
 export function serializeFilterForm(form) {
   const formData = new FormData(form);
   // Exclude metadata fields that don't represent filter state
@@ -1077,6 +1142,9 @@ export function installFilterReset({ toggleUnsavedIndicator }) {
     toggleUnsavedIndicator(viewId, false);
     if (window._viewInitialStates) {
       delete window._viewInitialStates[viewId];
+    }
+    if (viewId === '__new') {
+      clearNewViewFiltersStorage();
     }
 
     // Mark this swap as a reset so the entrypoint's afterSettle handler

--- a/assets/project-overview.js
+++ b/assets/project-overview.js
@@ -39,10 +39,16 @@ import {
   shouldShowResetChangesBtn,
   syncSaveChangesVisibility,
   syncResetChangesVisibility,
+  seedNewViewCacheFromStorage,
+  clearNewViewFiltersStorage,
 } from './filters.js';
 
 $(document).ready(function () {
   window.frontendDateFormat = $(document).find('#frontendDateFormat').val();
+  // Seed before the first htmx:afterSettle fires for #filtersContainer, so a
+  // persisted "+ new view" draft is already in _viewCachedFormData by the
+  // time the existing restore-from-cache code runs.
+  seedNewViewCacheFromStorage();
   initFiltersToggle();
   initProjectOverviewFilters({ refreshViewTable, toggleUnsavedIndicator });
   initProjectOverviewTable();
@@ -219,6 +225,9 @@ function initSaveChangesSubmit() {
     }
     const nameField = form.querySelector('#newViewName');
     if (nameField) nameField.value = name.trim();
+    // The draft is about to become a real saved view; drop the persisted
+    // copy so the next visit to "+ new view" starts pristine.
+    clearNewViewFiltersStorage();
   });
 }
 


### PR DESCRIPTION
#### Link to ticket

[#7632](https://leantime.itkdev.dk/#/tickets/showTicket/7632)

#### Description

When configuring the "pseudo view" called "+ ny visning", changes made to the filters are saved in localstorage to improve continuity.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
